### PR TITLE
Add `react-native link` instructions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ iOS | Android
 ## Install
 
 `npm install @yfuks/react-native-action-sheet@latest --save`
+`react-native link @yfuks/react-native-action-sheet`
 
 #### Android
+
+The `react-native link` command above should do everything you need, but if for some reason it does not work, you can replicate its effects manually by making the following changes.
+
 ```gradle
 // file: android/settings.gradle
 ...


### PR DESCRIPTION
I found that `react-native link` works out of the box and it's a lot simpler than manually editing files.  I opted to leave in the manual installation instructions but I think it would also be fine to remove them since `react-native link` works fine out of the box (at least in my experience).  Let me know if you'd prefer to remove them and I can make that change.