### PR TITLE
Don't mix import and module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-'use strict'
-
 import {
   NativeModules,
   Platform,
   ActionSheetIOS
 } from 'react-native';
 
-module.exports = (Platform.OS == 'ios') ? ActionSheetIOS : NativeModules.ActionSheetAndroid;
+export default (Platform.OS === 'ios') ? ActionSheetIOS : NativeModules.ActionSheetAndroid;


### PR DESCRIPTION
Hi @yfuks, and thanks for this library. :)

I'm trying to deploy my React Native project to the web using react-native-web (I'm still a long way from the end). I couldn't bundle my app without fixing this bit in your library though, so I guess the react-native packager is less strict.
