### PR TITLE
Remove deprecated Android package override

### DIFF
--- a/android/src/main/java/com/actionsheet/ActionSheetPackage.java
+++ b/android/src/main/java/com/actionsheet/ActionSheetPackage.java
@@ -17,11 +17,6 @@ public class ActionSheetPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }


### PR DESCRIPTION
This responds to a [breaking change](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) in React Native 0.47.0.