### PR TITLE
Resolve Android build issue

### DIFF
--- a/android/src/main/java/com/actionsheet/ActionSheetPackage.java
+++ b/android/src/main/java/com/actionsheet/ActionSheetPackage.java
@@ -20,4 +20,8 @@ public class ActionSheetPackage implements ReactPackage {
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }
+  
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return Collections.emptyList();
+  }
 }


### PR DESCRIPTION
I've been running into issues building a project with `react-native-action-sheet` on `react-native@0.59.10`.

I've found other dependencies that required `createJSModules` to be added to their `PackageNamePackage.java` file.