### PR TITLE
Android return cancel button index

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For the iOS implementation see [ActionSheetIOS](https://facebook.github.io/react
 static showActionSheetWithOptions(options, callback);
 ```
 
-@note: on Android in case of a touch outside the ActionSheet or the button *back* is pressed the buttonIndex value is ```'undefined'```
+@note: on Android in case of a touch outside the ActionSheet or the hardware back button is pressed, the buttonIndex value is `cancelButtonIndex` or ```'undefined'```
 
 #### options
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ static showActionSheetWithOptions(options, callback);
 option | iOS  | Android | Info
 ------ | ---- | ------- | ----
 options | OK | OK | (array of strings) - a list of button titles (required on iOS)
-cancelButtonIndex | OK | - | (int) - index of cancel button in options (useless in android since we have back button)
+cancelButtonIndex | OK | Ok | (int) - index of cancel button in options
 destructiveButtonIndex | OK | - | (int) - index of destructive button in options (same as above)
 title | OK | OK | (string) - a title to show above the action sheet
 message | OK | - | (string) - a message to show below the title

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For the iOS implementation see [ActionSheetIOS](https://facebook.github.io/react
 static showActionSheetWithOptions(options, callback);
 ```
 
-@note: on Android in case of a touch outside the ActionSheet or the hardware back button is pressed, the buttonIndex value is `cancelButtonIndex` or ```'undefined'```
+@note: on Android in case of a touch outside the ActionSheet or the hardware back button is pressed the buttonIndex value is `cancelButtonIndex` or ```'undefined'```
 
 #### options
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ You can change the style of the dialog by editing `nodes_modules/react-native-ac
 
 ```javascript
 import ActionSheet from 'react-native-action-sheet';
-import { Platform } from 'react-native';
 
-var BUTTONSiOS = [
+var options = [
   'Option 0',
   'Option 1',
   'Option 2',
@@ -81,17 +80,11 @@ var BUTTONSiOS = [
   'Cancel'
 ];
 
-var BUTTONSandroid = [
-  'Option 0',
-  'Option 1',
-  'Option 2'
-];
-
 var DESTRUCTIVE_INDEX = 3;
 var CANCEL_INDEX = 4;
 
 ActionSheet.showActionSheetWithOptions({
-  options: (Platform.OS == 'ios') ? BUTTONSiOS : BUTTONSandroid,
+  options: options,
   cancelButtonIndex: CANCEL_INDEX,
   destructiveButtonIndex: DESTRUCTIVE_INDEX,
   tintColor: 'blue'

--- a/android/src/main/java/com/actionsheet/ActionSheetModule.java
+++ b/android/src/main/java/com/actionsheet/ActionSheetModule.java
@@ -78,8 +78,14 @@ public class ActionSheetModule extends ReactContextBaseJavaModule {
     dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
       @Override
       public void onCancel(DialogInterface dialog) {
+        Integer index = null;
+
+        if (options.hasKey("cancelButtonIndex")) {
+          index = options.getInt("cancelButtonIndex");
+        }
+
         dialog.dismiss();
-        callback.invoke();
+        callback.invoke(index);
       }
     });
     dialog.show();


### PR DESCRIPTION
I think the callback should return the `cancelButtonIndex` when cancelled via the android back button.

This is our example of our usage in our app. The issue is that when the android back button is invoked the callback is invoked with `undefined`, which crashes at `options[index].action()`. If the `cancelButtonIndex` is instead returned then the code works as expected. 

```javascript
import ActionSheet from 'react-native-action-sheet';

let options = [
  { name: 'Option 0', action: () => {...} },
  { name: 'Option 1', action: () => {...} },
  { name: 'Option 2', action: () => {...} },
  { name: 'Cancel', action: () => {...} },
];

ActionSheet.showActionSheetWithOptions({
  options: options.map(o => o.name),
  cancelButtonIndex: 3,
},
index => {
  options[index].action()
});
```

I think this is a better solution as it more closely matches the behavior of the iOS API. Here's the updated readme. Which also seems simpler.

```javascript
import ActionSheet from 'react-native-action-sheet';

var options = [
  'Option 0',
  'Option 1',
  'Option 2',
  'Delete',
  'Cancel'
];

var DESTRUCTIVE_INDEX = 3;
var CANCEL_INDEX = 4;

ActionSheet.showActionSheetWithOptions({
  options: options,
  cancelButtonIndex: CANCEL_INDEX,
  destructiveButtonIndex: DESTRUCTIVE_INDEX,
  tintColor: 'blue'
},
(buttonIndex) => {
  console.log('button clicked :', buttonIndex);
});
```
